### PR TITLE
Changing the check for environment variable 'ENV'

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ docker run -d \
     --name manta-monitor-1
     --memory 1G \
     --label triton.cns.services=manta-monitor \
-    -e ENV=production \
+    -e JAVA_ENV=production \
     -e HONEYBADGER_API_KEY=XXXXXXXX \
     -e CONFIG_FILE=manta:///user/stor/manta-monitor-config.json \
     -e MANTA_USER=user \

--- a/src/main/java/com/joyent/manta/monitor/Application.java
+++ b/src/main/java/com/joyent/manta/monitor/Application.java
@@ -39,7 +39,7 @@ public class Application {
     }
     private static final String[] MANTA_REQUIRED_PARAMS = {"MANTA_USER",
                                                           "MANTA_URL",
-                                                          "ENV",
+                                                          "JAVA_ENV",
                                                           "HONEYBADGER_API_KEY",
                                                           "MANTA_METRIC_REPORTER_MODE",
                                                           "MANTA_HTTP_RETRIES",


### PR DESCRIPTION
The keyword 'ENV' is not being read, when the app is run via Docker. Hence, in this case, the error reported to honeybadger specifies the environment as 'unknown'.
The possible solution is to change the paramater 'ENV' to 'JAVA_ENV', which is also supported by honeybadger.