### PR TITLE
Adding mvn-error-prone check to the build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,11 +66,15 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
         <!-- Plugin versions -->
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
-        <maven-dependency-plugin.version>3.0.0</maven-dependency-plugin.version>
+        <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
         <maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
         <maven-extra-enforcer-rules.version>1.1</maven-extra-enforcer-rules.version>
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+
+        <!-- Maven plugin dependency versions -->
+        <maven-plexus-compiler-javac-errorprone.version>2.8.5</maven-plexus-compiler-javac-errorprone.version>
+        <maven-error-prone-core.version>2.3.2</maven-error-prone-core.version>
     </properties>
 
     <dependencies>
@@ -222,9 +226,31 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
+                    <compilerId>javac-with-errorprone</compilerId>
+                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
                     <source>${java.min.version}</source>
                     <target>${java.min.version}</target>
+                    <showWarnings>true</showWarnings>
+                    <compilerArgs>
+                        <arg>-Xlint:all</arg>
+                        <arg>-Xlint:-processing</arg>
+                        <arg>-XepDisableWarningsInGeneratedCode</arg>
+                    </compilerArgs>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.plexus</groupId>
+                        <artifactId>plexus-compiler-javac-errorprone</artifactId>
+                        <version>${maven-plexus-compiler-javac-errorprone.version}</version>
+                    </dependency>
+                    <!-- override plexus-compiler-javac-errorprone's dependency on
+                         Error Prone with the latest version -->
+                    <dependency>
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_core</artifactId>
+                        <version>${maven-error-prone-core.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/joyent/manta/monitor/CustomPrometheusCollector.java
+++ b/src/main/java/com/joyent/manta/monitor/CustomPrometheusCollector.java
@@ -116,6 +116,7 @@ public class CustomPrometheusCollector extends Collector {
                 value)));
     }
 
+    @Override
     public List<MetricFamilySamples> collect() {
         final ImmutableList.Builder<MetricFamilySamples> metricFamilySamplesBuilder =
                 ImmutableList.builder();

--- a/src/main/java/com/joyent/manta/monitor/chains/FileMultipartUploadGetDeleteChain.java
+++ b/src/main/java/com/joyent/manta/monitor/chains/FileMultipartUploadGetDeleteChain.java
@@ -23,7 +23,6 @@ import io.honeybadger.reporter.NoticeReporter;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-//import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 

--- a/src/main/java/com/joyent/manta/monitor/chains/FileMultipartUploadGetDeleteChain.java
+++ b/src/main/java/com/joyent/manta/monitor/chains/FileMultipartUploadGetDeleteChain.java
@@ -7,6 +7,7 @@
  */
 package com.joyent.manta.monitor.chains;
 
+import com.google.common.collect.ImmutableList;
 import com.joyent.manta.monitor.CustomPrometheusCollector;
 import com.joyent.manta.monitor.HoneyBadgerRequestFactory;
 import com.joyent.manta.monitor.InstanceMetadata;
@@ -22,7 +23,7 @@ import io.honeybadger.reporter.NoticeReporter;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import java.util.List;
+//import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -33,7 +34,7 @@ import static com.google.common.collect.ImmutableList.of;
  * that perform a mkdir, multipart file upload, get and delete.
  */
 public class FileMultipartUploadGetDeleteChain extends MantaOperationsChain {
-    private static final List<MantaOperationCommand> COMMANDS = of(
+    private static final ImmutableList<MantaOperationCommand> COMMANDS = of(
             GenerateFileCommand.INSTANCE,
             MkdirCommand.INSTANCE,
             MultipartPutFileCommand.INSTANCE,

--- a/src/main/java/com/joyent/manta/monitor/chains/FileUploadGetDeleteChain.java
+++ b/src/main/java/com/joyent/manta/monitor/chains/FileUploadGetDeleteChain.java
@@ -23,7 +23,6 @@ import io.honeybadger.reporter.NoticeReporter;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-//import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 

--- a/src/main/java/com/joyent/manta/monitor/chains/FileUploadGetDeleteChain.java
+++ b/src/main/java/com/joyent/manta/monitor/chains/FileUploadGetDeleteChain.java
@@ -7,6 +7,7 @@
  */
 package com.joyent.manta.monitor.chains;
 
+import com.google.common.collect.ImmutableList;
 import com.joyent.manta.monitor.CustomPrometheusCollector;
 import com.joyent.manta.monitor.HoneyBadgerRequestFactory;
 import com.joyent.manta.monitor.InstanceMetadata;
@@ -22,7 +23,7 @@ import io.honeybadger.reporter.NoticeReporter;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import java.util.List;
+//import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -33,7 +34,7 @@ import static com.google.common.collect.ImmutableList.of;
  * that perform a mkdir, file upload, get and delete.
  */
 public class FileUploadGetDeleteChain extends MantaOperationsChain {
-    private static final List<MantaOperationCommand> COMMANDS = of(
+    private static final ImmutableList<MantaOperationCommand> COMMANDS = of(
             GenerateFileCommand.INSTANCE,
             MkdirCommand.INSTANCE,
             PutFileCommand.INSTANCE,

--- a/src/main/java/com/joyent/manta/monitor/chains/MantaOperationsChain.java
+++ b/src/main/java/com/joyent/manta/monitor/chains/MantaOperationsChain.java
@@ -52,7 +52,7 @@ public class MantaOperationsChain extends ChainBase {
     private final AtomicBoolean completionStatus = new AtomicBoolean(false);
     private final CustomPrometheusCollector customPrometheusCollector;
 
-    private static final Map<Integer, String> STATUS_CODE_TO_TAG = ImmutableMap.of(
+    private static final ImmutableMap<Integer, String> STATUS_CODE_TO_TAG = ImmutableMap.of(
         HttpStatus.SC_INTERNAL_SERVER_ERROR, "internal-server-error",
         HttpStatus.SC_BAD_GATEWAY, "bad-gateway",
         HttpStatus.SC_GATEWAY_TIMEOUT, "gateway-timeout",

--- a/src/main/java/com/joyent/manta/monitor/servlets/MantaMonitorServlet.java
+++ b/src/main/java/com/joyent/manta/monitor/servlets/MantaMonitorServlet.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicLong;
 @Singleton
 public class MantaMonitorServlet extends HttpServlet {
     private static final Logger LOG = LoggerFactory.getLogger(MantaMonitorServlet.class);
+    private static final long serialVersionUID = 5240172014702531193L;
     private final Map<String, AtomicLong> clientStats;
 
     @Inject
@@ -35,6 +36,7 @@ public class MantaMonitorServlet extends HttpServlet {
         this.clientStats = clientStats;
     }
 
+    @Override
     protected void doGet(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
         if (clientStats.size() > 0) {
             response.setContentType("application/json");


### PR DESCRIPTION
[skip travis] This commit includes the pom chnages to add maven error prone check for the project. It also includes other miscellaneous changes to clear the warnings from the error-prone compiler.