### PR TITLE
Removing the code to delete temp file in GenerateFileCommand.java

### DIFF
--- a/src/main/java/com/joyent/manta/monitor/commands/GenerateFileCommand.java
+++ b/src/main/java/com/joyent/manta/monitor/commands/GenerateFileCommand.java
@@ -9,7 +9,6 @@ package com.joyent.manta.monitor.commands;
 
 import com.joyent.manta.monitor.MantaOperationContext;
 import com.joyent.manta.monitor.RandomAlphabeticInputStream;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomUtils;
 
@@ -37,10 +36,6 @@ public class GenerateFileCommand implements MantaOperationCommand {
         final Path temp = Files.createTempFile(String.format("mput-%s-",
                 LocalDate.now().format(ISO_LOCAL_DATE)),
                 ".txt");
-
-        /* Register the file for deletion upon the JVM's exit, so that
-         * we don't have junk cluttering up our filesystem. */
-        FileUtils.forceDeleteOnExit(temp.toFile());
 
         final MessageDigest checksum = MessageDigest.getInstance("SHA256");
 

--- a/src/main/java/com/joyent/manta/monitor/commands/PutFileCommand.java
+++ b/src/main/java/com/joyent/manta/monitor/commands/PutFileCommand.java
@@ -62,6 +62,8 @@ public class PutFileCommand implements MantaOperationCommand {
         } catch (RuntimeException e) {
             throw new MantaOperationException(e).setPath(filePath);
         } finally {
+            /* Delete the temp file so that we don't have junk cluttering
+             * up our filesystem. */
             Files.deleteIfExists(context.getTestFile());
             LOG.info("Put operation took: {} milliseconds", stopwatch.elapsed(TimeUnit.MILLISECONDS));
         }


### PR DESCRIPTION
The line:43 in the GenerateFileCommand.java seems to be retaining maximum heap space which causes OutOfMemory issues.
The temp files will still be deleted in the line:67 of the PutFileCommand.java and line:58 of the MultipartPutFileCommand.java.
Hence removing the code from the GenerateFileCommand.java.
[skip travis]