### PR TITLE
Accepting keystore paths as manta URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,38 @@ docker run -p 8443:8443 -d \
     -e JETTY_SERVER_SECURE_PORT=8443 \
     joyent/manta-monitor
 ```
-NOTE : For detailed information about about generating and using keystore 
-refer [here](https://www.eclipse.org/jetty/documentation/9.4.x/configuring-ssl.html#configuring-jetty-for-ssl)
+NOTES : 
+* For detailed information about about generating and using keystore 
+  refer [here](https://www.eclipse.org/jetty/documentation/9.4.x/configuring-ssl.html#configuring-jetty-for-ssl)
+* As seen above, the *docker run* command requires mounting the keystore and truststore files to the docker container. 
+  However, in case if these files are not accessible from the local file system, you can provide a manta URL, as shown below,
+  to make these files accessible during run time. Make sure to put the files in the MANTA_USER's manta store before running the
+  below command.
+  
+```
+docker run -p 8443:8443 -d \
+    --name manta-monitor-1
+    --memory 1G \
+    --label triton.cns.services=manta-monitor \
+    -e JAVA_ENV=production \
+    -e HONEYBADGER_API_KEY=XXXXXXXX \
+    -e CONFIG_FILE=manta:///user/stor/manta-monitor-config.json \
+    -e MANTA_USER=user \
+    -e "MANTA_PUBLIC_KEY=$(cat $HOME/.ssh/id_rsa.pub)" \
+    -e "MANTA_PRIVATE_KEY=$(cat $HOME/.ssh/id_rsa | base64 -w0)" \
+    -e "MANTA_URL=https://us-east.manta.joyent.com" \
+    -e MANTA_TIMEOUT=4000 \
+    -e MANTA_METRIC_REPORTER_MODE=JMX \
+    -e MANTA_HTTP_RETRIES=3 \
+    -e ENABLE_TLS=true \
+    -e KEYSTORE_PATH=manta:///user/stor/keystore \
+    -e KEYSTORE_PASS=//XXXXXXXX \
+    -e TRUSTSTORE_PATH=manta:///user/stor/truststore \
+    -e TRUSTSTORE_PASS=XXXXXXXX \
+    -e JETTY_SERVER_SECURE_PORT=8443 \
+    joyent/manta-monitor
+```  
 
-Additional notes: 
 * The parameter MANTA_HTTP_RETRIES, above defines the number of times to retry failed HTTP requests. 
   Setting this value to zero disables retries completely.
   Please refer [here](https://github.com/joyent/java-manta/blob/master/USAGE.md#parameters) 

--- a/src/main/java/com/joyent/manta/monitor/Application.java
+++ b/src/main/java/com/joyent/manta/monitor/Application.java
@@ -63,7 +63,9 @@ public class Application {
         final MantaMonitorServletModule mantaMonitorServletModule = new MantaMonitorServletModule();
         final Injector injector = Guice.createInjector(module);
         final Configuration configuration = injector.getInstance(Configuration.class);
-        final JettyServerBuilderModule jettyServerBuilderModule = new JettyServerBuilderModule(jettyServerPort);
+        final MantaClient client = injector.getInstance(MantaClient.class);
+        final JettyServerBuilderModule jettyServerBuilderModule = new JettyServerBuilderModule(jettyServerPort,
+                client);
         final Injector jettyServerBuilderInjector = injector.createChildInjector(jettyServerBuilderModule, mantaMonitorServletModule);
         LOG.info("Starting Manta Monitor");
         final MantaMonitorJerseyServer server = jettyServerBuilderInjector.getInstance(MantaMonitorJerseyServer.class);
@@ -80,7 +82,7 @@ public class Application {
             System.exit(1);
         }
 
-        final Set<ChainRunner> runningChains = startAllChains(configuration, injector);
+        final Set<ChainRunner> runningChains = startAllChains(configuration, injector, client);
 
         while (!runningChains.isEmpty()) {
             runningChains.removeIf(chainRunner -> !chainRunner.isRunning());
@@ -102,13 +104,14 @@ public class Application {
      *
      * @param configuration configuration to load
      * @param injector Guice DI object
+     * @param client MantaClient object
      * @return a set of all chain runners started
      */
     private static Set<ChainRunner> startAllChains(final Configuration configuration,
-                                                   final Injector injector) {
+                                                   final Injector injector,
+                                                   final MantaClient client) {
         final Set<ChainRunner> runningChains =
                 new LinkedHashSet<>(configuration.getTestRunners().size());
-        final MantaClient client = injector.getInstance(MantaClient.class);
         /**
          * A Shared Map for storing the Histogram object for each chain.
          * This map is shared across all the running chains with key as the name

--- a/src/main/java/com/joyent/manta/monitor/JerseyGuiceServletContextListener.java
+++ b/src/main/java/com/joyent/manta/monitor/JerseyGuiceServletContextListener.java
@@ -12,6 +12,9 @@ import com.google.inject.servlet.GuiceServletContextListener;
 
 import javax.inject.Inject;
 
+/**
+ * Class that provides event listener to the {@link MantaMonitorJerseyServer}.
+ */
 public class JerseyGuiceServletContextListener extends GuiceServletContextListener {
     private final Injector injector;
 

--- a/src/main/java/com/joyent/manta/monitor/JettyServerBuilderModule.java
+++ b/src/main/java/com/joyent/manta/monitor/JettyServerBuilderModule.java
@@ -9,16 +9,22 @@ package com.joyent.manta.monitor;
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
+import com.joyent.manta.client.MantaClient;
 import io.logz.guice.jersey.configuration.JerseyConfiguration;
+import org.jetbrains.annotations.Nullable;
 
 /**
- * Class that provides {@link MantaMonitorModule} dependencies to the {@link MantaMonitorServletModule}.
+ * Class that provides {@link MantaMonitorModule} dependencies to the
+ * {@link MantaMonitorServletModule}.
  */
 public class JettyServerBuilderModule implements Module {
     private final int jettyServerPort;
+    private final MantaClient client;
 
-    public JettyServerBuilderModule(final int jettyServerPort) {
+    public JettyServerBuilderModule(final int jettyServerPort,
+                                    @Nullable final MantaClient client) {
         this.jettyServerPort = jettyServerPort;
+        this.client = client;
     }
 
     @Override
@@ -27,7 +33,7 @@ public class JettyServerBuilderModule implements Module {
                 .addPort(jettyServerPort)
                 .build();
 
-        MantaMonitorJerseyModule mantaMonitorJerseyModule = new MantaMonitorJerseyModule(jerseyConfig);
+        MantaMonitorJerseyModule mantaMonitorJerseyModule = new MantaMonitorJerseyModule(jerseyConfig, client);
         binder.install(mantaMonitorJerseyModule);
     }
 }

--- a/src/main/java/com/joyent/manta/monitor/MantaMonitorJerseyModule.java
+++ b/src/main/java/com/joyent/manta/monitor/MantaMonitorJerseyModule.java
@@ -11,34 +11,40 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Provider;
 import com.google.inject.servlet.ServletModule;
+import com.joyent.manta.client.MantaClient;
 import io.logz.guice.jersey.JettyServerCreator;
 import io.logz.guice.jersey.configuration.JerseyConfiguration;
 import java.util.Objects;
 import org.eclipse.jetty.server.Server;
 
 /**
- * This implementation of {@link AbstractModule} provides dependency injection for the creating and configuring
- * {@link MantaMonitorJerseyServer}.
+ * This implementation of {@link AbstractModule} provides dependency injection
+ * for the creating and configuring {@link MantaMonitorJerseyServer}.
  */
 
 public class MantaMonitorJerseyModule extends AbstractModule {
     private final JerseyConfiguration jerseyConfiguration;
     private final JettyServerCreator jettyServerCreator;
+    private final MantaClient client;
 
-    public MantaMonitorJerseyModule(final JerseyConfiguration jerseyConfiguration) {
-        this(jerseyConfiguration, Server::new);
+    public MantaMonitorJerseyModule(final JerseyConfiguration jerseyConfiguration,
+                                    final MantaClient client) {
+        this(jerseyConfiguration, Server::new, client);
     }
 
-    public MantaMonitorJerseyModule(final JerseyConfiguration jerseyConfiguration, final JettyServerCreator jettyServerCreator) {
+    public MantaMonitorJerseyModule(final JerseyConfiguration jerseyConfiguration,
+                                    final JettyServerCreator jettyServerCreator,
+                                    final MantaClient client) {
         this.jerseyConfiguration = Objects.requireNonNull(jerseyConfiguration);
         this.jettyServerCreator = Objects.requireNonNull(jettyServerCreator);
+        this.client = Objects.requireNonNull(client);
     }
 
     protected void configure() {
         Provider<Injector> injectorProvider = this.getProvider(Injector.class);
         this.install(new ServletModule());
         this.bind(MantaMonitorJerseyServer.class).toInstance(new MantaMonitorJerseyServer(this.jerseyConfiguration,
-                injectorProvider::get, this.jettyServerCreator));
+                injectorProvider::get, this.jettyServerCreator, this.client));
         this.bind(JerseyConfiguration.class).toInstance(this.jerseyConfiguration);
     }
 }

--- a/src/main/java/com/joyent/manta/monitor/MantaMonitorJerseyServer.java
+++ b/src/main/java/com/joyent/manta/monitor/MantaMonitorJerseyServer.java
@@ -47,7 +47,7 @@ import java.util.List;
 
 public class MantaMonitorJerseyServer {
     private static final Logger LOGGER = LoggerFactory.getLogger(MantaMonitorJerseyServer.class);
-    private static final String MANTA_MONITOR_SUBDIR = ".manta-monitor";
+    private static final String MANTA_MONITOR_SUBDIR = "tls";
     private final JerseyConfiguration jerseyConfiguration;
     private final GuiceServletContextListener contextListener;
     private final Server server;

--- a/src/main/java/com/joyent/manta/monitor/MantaMonitorJerseyServer.java
+++ b/src/main/java/com/joyent/manta/monitor/MantaMonitorJerseyServer.java
@@ -151,7 +151,7 @@ public class MantaMonitorJerseyServer {
             }
 
         } catch (IllegalArgumentException | NullPointerException e) {
-            String msg = String.format("Invalid URI for configuration file: %s",
+            String msg = String.format("Invalid URI for store path: %s",
                     uriString);
             LOGGER.error(msg, e);
             System.exit(1);

--- a/src/main/java/com/joyent/manta/monitor/MantaMonitorJerseyServer.java
+++ b/src/main/java/com/joyent/manta/monitor/MantaMonitorJerseyServer.java
@@ -47,6 +47,7 @@ import java.util.List;
 
 public class MantaMonitorJerseyServer {
     private static final Logger LOGGER = LoggerFactory.getLogger(MantaMonitorJerseyServer.class);
+    private static final String MANTA_SUBDIR = ".manta-monitor";
     private final JerseyConfiguration jerseyConfiguration;
     private final GuiceServletContextListener contextListener;
     private final Server server;
@@ -227,7 +228,8 @@ public class MantaMonitorJerseyServer {
             if ("manta".equals(keystoreURI.getScheme())) {
                 // Make the keystore file available for the sslContextFactory, by
                 // reading the remote file and writing it to a file on the host file system.
-                File keystoreTargetFile = new File(userHomePath + "/keystore");
+                File keystoreTargetFile = new File(userHomePath + File.separator
+                        + MANTA_SUBDIR + File.separator + "keystore");
                 writeInputStreamToTarget(keystoreURI, keystoreTargetFile);
                 sslContextFactory.setKeyStorePath(keystoreTargetFile.getPath());
             } else {
@@ -239,7 +241,8 @@ public class MantaMonitorJerseyServer {
             if ("manta".equals(trustStoreURI.getScheme())) {
                 // Make the truststore file available for the sslContextFactory, by
                 // reading the remote file and writing it to a file on the host file system.
-                File trustStoreTargetFile = new File(userHomePath + "/truststore");
+                File trustStoreTargetFile = new File(userHomePath + File.separator
+                        + MANTA_SUBDIR + File.separator + "truststore");
                 writeInputStreamToTarget(trustStoreURI, trustStoreTargetFile);
                 sslContextFactory.setTrustStorePath(trustStoreTargetFile.getPath());
             } else {

--- a/src/main/java/com/joyent/manta/monitor/MantaMonitorJerseyServer.java
+++ b/src/main/java/com/joyent/manta/monitor/MantaMonitorJerseyServer.java
@@ -47,7 +47,7 @@ import java.util.List;
 
 public class MantaMonitorJerseyServer {
     private static final Logger LOGGER = LoggerFactory.getLogger(MantaMonitorJerseyServer.class);
-    private static final String MANTA_SUBDIR = ".manta-monitor";
+    private static final String MANTA_MONITOR_SUBDIR = ".manta-monitor";
     private final JerseyConfiguration jerseyConfiguration;
     private final GuiceServletContextListener contextListener;
     private final Server server;
@@ -220,16 +220,17 @@ public class MantaMonitorJerseyServer {
             httpsConfig.addCustomizer(src);
 
             SslContextFactory sslContextFactory = new SslContextFactory();
-
-            String userHomePath = System.getProperty("user.home");
+            // Write the keystore and the truststore files in the user's current
+            // working directory. For eg: /opt/manta-monitor/.manta-monitor/keystore
+            String userDirPath = System.getProperty("user.dir");
 
             URI keystoreURI = getURIFromString(System.getenv("KEYSTORE_PATH"));
 
             if ("manta".equals(keystoreURI.getScheme())) {
                 // Make the keystore file available for the sslContextFactory, by
                 // reading the remote file and writing it to a file on the host file system.
-                File keystoreTargetFile = new File(userHomePath + File.separator
-                        + MANTA_SUBDIR + File.separator + "keystore");
+                File keystoreTargetFile = new File(userDirPath + File.separator
+                        + MANTA_MONITOR_SUBDIR + File.separator + "keystore");
                 writeInputStreamToTarget(keystoreURI, keystoreTargetFile);
                 sslContextFactory.setKeyStorePath(keystoreTargetFile.getPath());
             } else {
@@ -241,8 +242,8 @@ public class MantaMonitorJerseyServer {
             if ("manta".equals(trustStoreURI.getScheme())) {
                 // Make the truststore file available for the sslContextFactory, by
                 // reading the remote file and writing it to a file on the host file system.
-                File trustStoreTargetFile = new File(userHomePath + File.separator
-                        + MANTA_SUBDIR + File.separator + "truststore");
+                File trustStoreTargetFile = new File(userDirPath + File.separator
+                        + MANTA_MONITOR_SUBDIR + File.separator + "truststore");
                 writeInputStreamToTarget(trustStoreURI, trustStoreTargetFile);
                 sslContextFactory.setTrustStorePath(trustStoreTargetFile.getPath());
             } else {


### PR DESCRIPTION
This commit adds ability to the user to provide the environment variables KEYSTORE_PATH and TRUSTSTORE_PATH  as manta URLs, while using the application in the TLS mode. For eg:
```
-e KEYSTORE_PATH=manta:///user/stor/keystore
-e TRUSTSTORE_PATH=manta:///user/stor/truststore
```
With this, the user can pre upload the keystore and the truststore files in its manta object store and the application will then read the files and use them as required.

The code doesn't add to the heap usage of the application as seen below:

<img width="1105" alt="manta-monitor-heapusage" src="https://user-images.githubusercontent.com/37811940/53833099-a1ffe300-3f3c-11e9-9967-fcbb2cd463a3.png">

This also addresses the concern in the [QA-377](https://jira.joyent.us/browse/QA-377?focusedCommentId=238265&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-238265) 